### PR TITLE
Fix mapping error and typo

### DIFF
--- a/js/ace.js
+++ b/js/ace.js
@@ -72,7 +72,7 @@ var smartAce = (function() {
 			tactileobject: 'tactileObject',
 			timingcontrol: 'timingControl',
 			transcript: 'transcript',
-			ttsMarkup: 'ttsmarkup',
+			ttsmarkup: 'ttsMarkup',
 			unknown: 'unknown'
 		}
 	};

--- a/js/config/messages.js
+++ b/js/config/messages.js
@@ -112,16 +112,16 @@ var smart_ui = {
 				"en": "Checks related to these types have been turned off. To re-enable these checks, see the Conformance Verification tab."
 			},
 			"a11yMetadata": {
-				"en": "The following accessibiity metadata was set based on the Ace report:"
+				"en": "The following accessibility metadata was set based on the Ace report:"
 			},
 			"verifyMetadata": {
 				"en": "Verify the accuracy of these assumptions in the Discovery Metadata tab."
 			},
 			"unknownFeatures": {
-				"en": "The following accessibiity features were found in the metadata but do not match known values:"
+				"en": "The following accessibility features were found in the metadata but do not match known values:"
 			},
 			"obsoleteFeatures": {
-				"en": "The following accessibiity features are no longer recommended (the values in parentheses have been used instead):"
+				"en": "The following accessibility features are no longer recommended (the values in parentheses have been used instead):"
 			},
 			"verifyFeatures": {
 				"en": "Verify these features are not typos or invalid."

--- a/php/version.php
+++ b/php/version.php
@@ -1,4 +1,4 @@
 
 <?php
-	$smart_version = '2023-12-01T12:00:00Z'; # used to refresh all css and js in browsers 
+	$smart_version = '2024-01-25T12:00:00Z'; # used to refresh all css and js in browsers 
 ?>


### PR DESCRIPTION
Fixes the reverse mapping of ttsMarkup in the ace imports that incorrectly would label the metadata as unknown.

Fixes the typo "accessibiity" in a few messages.

Fixes #5 