### PR TITLE
Split conformance from specification

### DIFF
--- a/css/report.css
+++ b/css/report.css
@@ -169,10 +169,6 @@ div.summaryTable > div > div.pass {
 	background-color: rgb(230,240,230);
 }
 
-div.summaryTable > div > div.fail {
-	background-color: rgb(240,230,230);
-}
-
 div.summaryTable > div > div.incomplete {
 	background-color: rgb(255,255,190);
 }

--- a/js/config/messages.js
+++ b/js/config/messages.js
@@ -304,6 +304,9 @@ var smart_ui = {
 			"overview": {
 				"en": "Overview"
 			},
+			"eval": {
+				"en": "Evaluated Against"
+			},
 			"conformance": {
 				"en": "Conformance"
 			},

--- a/js/conformance.js
+++ b/js/conformance.js
@@ -447,12 +447,6 @@ var smartConformance = (function() {
 		
 		var incomplete = document.querySelectorAll(a_unverified_selector);
 		
-		if (incomplete.length > 0) {
-			status_label.textContent = smart_ui.conformance.status.incomplete[smart_lang];
-			status_input.value = 'incomplete';
-			return;
-		}
-		
 		var onix_a = document.getElementById('onix02');
 		var onix_aa = document.getElementById('onix03');
 		
@@ -468,12 +462,18 @@ var smartConformance = (function() {
 		var wcag_ver = 'wcag' + wcag_version.replace('.','');
 		var epub_ver = 'epub' + epub_a11y.replace('.','');
 		
-		// prep pass message
-		var conformance_status = smart_ui.conformance.status.pass[smart_lang] + ': ';
-			conformance_status += smart_ui.conformance.status[epub_ver][smart_lang];
-			conformance_status += ' - ';
-			conformance_status += smart_ui.conformance.status[wcag_ver][smart_lang];
-			conformance_status += ' ';
+		// prep spec version being tested
+		var spec_version = smart_ui.conformance.status[epub_ver][smart_lang];
+			spec_version += ' - ';
+			spec_version += smart_ui.conformance.status[wcag_ver][smart_lang];
+			spec_version += ' ';
+		
+		// bail out if not all criteria have been evaluated
+		if (incomplete.length > 0) {
+			status_label.textContent = smart_ui.conformance.status.incomplete[smart_lang] + ': ' + spec_version + smart_ui.conformance.status[smartWCAG.WCAGLevel()][smart_lang];
+			status_input.value = 'incomplete';
+			return;
+		}
 		
 		// checks that there aren't any failures if AA is specified
 		// or if showing optional AA success criteria and all have been checked
@@ -481,7 +481,7 @@ var smartConformance = (function() {
 			
 			if (level_a_pass && document.querySelectorAll(aa_fail_selector).length == 0) {
 				
-				status_label.textContent = conformance_status + smart_ui.conformance.status.aa[smart_lang];
+				status_label.textContent = smart_ui.conformance.status.pass[smart_lang] + ': ' + spec_version + smart_ui.conformance.status.aa[smart_lang];
 				
 				status_input.value = 'aa';
 				
@@ -494,7 +494,7 @@ var smartConformance = (function() {
 		// otherwise not having an else if here allows verification to fall through to A, even if testing AA
 		if (level_a_pass) {
 			
-			status_label.textContent = conformance_status + smart_ui.conformance.status.a[smart_lang];
+			status_label.textContent = smart_ui.conformance.status.pass[smart_lang] + ': ' + spec_version + smart_ui.conformance.status.a[smart_lang];
 			
 			status_input.value = 'a';
 			
@@ -503,7 +503,7 @@ var smartConformance = (function() {
 		}
 		
 		else {
-			status_label.textContent = smart_ui.conformance.status.fail[smart_lang];
+			status_label.textContent = smart_ui.conformance.status.fail[smart_lang] + ': ' + spec_version + smart_ui.conformance.status[smartWCAG.WCAGLevel()][smart_lang];
 			status_input.value = 'fail';
 			if (onix_aa.checked) { onix_aa.click(); }
 			if (onix_a.checked) { onix_a.click(); }

--- a/js/reporting.js
+++ b/js/reporting.js
@@ -420,11 +420,20 @@ var smartReport = (function() {
 		
 		var conf = document.getElementById('conformance-result').value;
 		
+		var result = document.getElementById('conformance-result-status').textContent.match(/^(?<status>Pass|Failed|Incomplete): (?<spec>.*?)$/).groups;
+		
+		summaryTable.appendChild(formatPubInfoEntry({
+			id: 'conformance-spec',
+			label: smart_ui.reporting.tabs.eval[smart_lang],
+			value: result.spec,
+			property: (result.status == 'Pass' ? 'dcterms:conformsTo' : '')
+		}));
+		
 		summaryTable.appendChild(formatPubInfoEntry({
 			id: 'conformance-result',
 			label: smart_ui.reporting.tabs.conformance[smart_lang],
-			value: document.getElementById('conformance-result-status').textContent, property: 'dcterms:conformsTo',
-			value_bg_class: conf
+			value: result.status,
+			value_bg_class: ((conf == 'a' || conf == 'aa') ? 'pass' : conf)
 		}));
 		
 		// add user extension properties

--- a/new.html
+++ b/new.html
@@ -16,6 +16,14 @@
 				<h2>What's New</h2>
 				
 				<dl>
+					<dt>February 23, 2024 &#8212; Added specification to all reports</dt>
+					<dd>
+						<p>In the generated reports, the version of the EPUB Accessibility specification and WCAG
+							tested against was only reported if the publication passed. This information is now
+							available regardless of the outcome. The specification is also on a separate line from
+							the test status.</p>
+					</dd>
+					
 					<dt>September 21, 2023 &#8212; Updated distribution metadata</dt>
 					<dd>
 						<p>The Distribution metadata tab has been updated to match the new values available in ONIX code list

--- a/php/version.php
+++ b/php/version.php
@@ -1,4 +1,4 @@
 
 <?php
-	$smart_version = '2024-01-25T12:00:00Z'; # used to refresh all css and js in browsers 
+	$smart_version = '2024-02-23T12:00:00Z'; # used to refresh all css and js in browsers 
 ?>


### PR DESCRIPTION
This PR adds the EPUB and WCAG specifications tested against to the final report regardless of the testing outcome.

It also separates the specification from the status to improve readability.

Fixes #7