### PR TITLE
Default GCA users to WCAG 2.2 evaluations

### DIFF
--- a/js/ace.js
+++ b/js/ace.js
@@ -134,7 +134,8 @@ var smartAce = (function() {
 		
 		
 		var epub_version = _EPUB_DEFAULT_VERSION;
-		var wcag_version = _WCAG_DEFAULT_VERSION;
+		// temporary patch so GCA reports default to 2.2 - remove when this becomes site standard
+		var wcag_version = smart_extensions.hasOwnProperty('born_accessible') ? '2.2' : _WCAG_DEFAULT_VERSION;
 		var wcag_level = _WCAG_DEFAULT_LEVEL;
 		
 		if (conformance_url) {
@@ -177,7 +178,7 @@ var smartAce = (function() {
 		smartConformance.setEPUBA11yVersion(epub_version);
 		
 		document.getElementById('wcag-version').value = wcag_version;
-		smartConformance.setWCAGVersion(wcag_version,false);
+		smartConformance.setWCAGVersion(wcag_version);
 		
 		document.getElementById('wcag-level').value = wcag_level;
 		smartConformance.setWCAGConformanceLevel(wcag_level);

--- a/js/conformance.js
+++ b/js/conformance.js
@@ -154,7 +154,7 @@ var smartConformance = (function() {
 		else if (version == '1.0') {
 			wcag_ver.value = '2.0';
 			wcag_ver.disabled = true;
-			setWCAGVersion('2.0',false);
+			setWCAGVersion('2.0');
 		}
 		
 		else {
@@ -168,7 +168,7 @@ var smartConformance = (function() {
 	
 	/* changes the visible success criteria based on the user setting */
 	
-	function setWCAGVersion(version, displayAlert) {
+	function setWCAGVersion(version) {
 		smartWCAG.setWCAGVersion(version);
 		adjustWCAGSC(version);
 		setWCAGConformanceLevel(smartWCAG.WCAGLevel());
@@ -632,8 +632,8 @@ var smartConformance = (function() {
 			setEPUBA11yVersion(version);
 		},
 		
-		setWCAGVersion: function(version,alert) {
-			setWCAGVersion(version,alert);
+		setWCAGVersion: function(version) {
+			setWCAGVersion(version);
 		},
 		
 		setWCAGConformanceLevel: function(level) {

--- a/js/init-smart.js
+++ b/js/init-smart.js
@@ -98,6 +98,13 @@
 			else if (data.category == 'newEvaluation') {
 				// only the title to set if a new blank evaluation
 				document.getElementById('title').value = data.title;
+				
+				// temporary patch until site default becomes 2.2
+				if (smart_extensions.hasOwnProperty('born_accessible')) {
+					document.getElementById('wcag-version').value = '2.2';
+					smartConformance.setWCAGVersion('2.2');
+				}
+				
 			}
 		}
 		

--- a/js/manage.js
+++ b/js/manage.js
@@ -522,7 +522,7 @@ var smartManage = (function() {
 			
 			document.getElementById('wcag-version').value = wcag_version;
 			
-			smartConformance.setWCAGVersion(wcag_version, false);
+			smartConformance.setWCAGVersion(wcag_version);
 			
 			if ((evaluationJSON.configuration.wcag.show_aa && evaluationJSON.configuration.wcag.show_aa == 'true') && evaluationJSON.configuration.wcag.level != 'aa') {
 				document.getElementById('show-aa').click();

--- a/php/version.php
+++ b/php/version.php
@@ -1,4 +1,4 @@
 
 <?php
-	$smart_version = '2024-02-23T12:00:00Z'; # used to refresh all css and js in browsers 
+	$smart_version = '2024-03-13T16:00:00Z'; # used to refresh all css and js in browsers 
 ?>


### PR DESCRIPTION
Also removes some old code that used to warn that 2.2 was not yet a REC.