### PR TITLE
Reformat distribution tab and styles

### DIFF
--- a/css/a11y.css
+++ b/css/a11y.css
@@ -178,8 +178,7 @@ h2{
 	font-family: Raleway;
 	font-size: 2.4rem;
 	font-weight: normal;
-	color: rgb(0, 0, 180);
-	margin-top: 1rem;
+	margin-top: 2rem;
 }
 
 h3{
@@ -271,6 +270,7 @@ a#ace-review {
 section#start label,
 section#start fieldset legend {
 	font-size: 100%;
+	color: rgb(0,0,120) !important;
 }
 
 /* conformance guidelines */
@@ -427,21 +427,24 @@ p.help a {
 /* conformance results */
 
 div.conformance-result {
-	padding: 1rem 0 1rem 1.5rem;
-	margin-bottom: 1rem;
+	padding: 1rem 0 0 1.3rem;
 }
 
 span.hd {
-	font-size: 110%;
 	color: rgb(0,0,120);
 }
 
 span#conformance-result-status {
-	padding-left: 4rem;
+	padding-left: 5rem;
+	color: rgb(0,0,0);
 }
 
 fieldset#eval-info legend {
 	margin-bottom: 2rem;
+}
+
+#eval-info label.data {
+	margin-top: 1.5rem;
 }
 
 
@@ -524,19 +527,22 @@ fieldset,
 div.conformance-result,
 div.onix {
 	border: none;
-	background-color: rgb(251,251,251);
-	border-radius: 0.5rem;
-	box-shadow: 0 0 0.2rem 0 grey;
-	padding: 2rem;
 }
 
-div.onix,
-div.conformance-result {
+div.onix {
 	margin-left: 0.2rem;
 }
 
 fieldset {
-	margin-top: 4rem;
+	margin-top: 0;
+}
+
+#discovery-fields fieldset {
+	margin-top: 3rem;
+}
+
+#discovery-fields fieldset legend {
+	border-bottom: 0.1rem solid rgb(0,0,120);
 }
 
 fieldset#accessModeSufficient fieldset {
@@ -607,7 +613,7 @@ fieldset.status > label {
 section#verification > div.form-data > fieldset,
 div.form-data > fieldset,
 div.form-data > label {
-	margin: 1rem;
+	margin: 1rem 0 1.25rem 1rem;
 }
 
 section#verification > div.form-data > fieldset > legend {
@@ -624,10 +630,7 @@ fieldset select {
 }
 
 div.form-data {
-	background-color: rgb(251,251,251);
 	padding: 0.3rem 0 0.3rem 1rem;
-	border-radius: 0.5rem;
-	box-shadow: 0 0 0.2rem 0 grey;
 	margin-left: 0.2rem !important;
 }
 
@@ -845,11 +848,15 @@ section#config small{
 	font-style: italic;
 }
 
-textarea{
+textarea {
 	width: 90%;
 }
 
-label.data > textarea{
+textarea#accessibilitySummary {
+	margin-top: 2rem;
+}
+
+label.data > textarea {
 	width: 39.8rem;
 	display: inline-block;
 }
@@ -881,6 +888,7 @@ div.combo > label:first-child span {
 	display: inline-block;
 	width: 20rem;
 	vertical-align: top;
+	color: rgb(0,0,120);
 }
 
 label.data > input[type = 'text'],
@@ -889,7 +897,7 @@ div.combo > label > input[type='text'] {
 }
 
 div.data{
-	margin: 3rem 0 2rem 0;
+	margin: 0 0 2rem 0;
 }
 
 div.data > div{
@@ -1121,11 +1129,24 @@ div.onix textarea {
 	margin-top: 1rem;
 }
 
+.onix-optional {
+	margin-top: 2rem;
+	color: rgb(0,0,120);
+}
+
+#distribution-fields input[type=text] {
+	min-width: 40rem;
+}
+
+#distribution-fields dt {
+	font-weight: normal;
+	color: rgb(0,0,120);
+	margin-bottom: 1rem;
+}
 
 /* pub info fieldsets */
 
 div.data > fieldset.flat > legend {
-	color: rgb(0,0,0) !important;
 	width: 20rem;
 }
 

--- a/extensions/born_accessible/css/smart.css
+++ b/extensions/born_accessible/css/smart.css
@@ -4,16 +4,19 @@
 }
 
 #born_accessible h3 {
-	margin-bottom: 0;
 	font-size: 135%;
 	font-weight: normal;
+	border-bottom: 0.1rem solid rgb(0,0,120);
+	padding-bottom: 1rem;
+	margin-top: -1rem;
+	margin-bottom: 2rem;
 }
 
 #born_accessible h4 {
 	font-size: 120%;
 	font-weight: normal;
 	color: rgb(0,0,180);
-	margin: 7rem 0 0 0;
+	margin: 3rem 0 0 0;
 }
 
 #born_accessible > section {
@@ -26,7 +29,7 @@
 }
 
 #born_accessible > section#ba-scoring > div.form-data {
-	margin-top: 3rem;
+	margin-top: -1rem;
 }
 
 #born_accessible > fieldset + section {
@@ -65,6 +68,9 @@
 #born_accessible fieldset.test {
 	border: 0.2rem solid rgb(255, 255, 180);
 	background-color: rgb(250,250,250);
+	margin-top: 2rem;
+	padding: 2rem;
+	border-radius: 0.5rem;
 }
 
 #born_accessible fieldset > .ba-label {

--- a/js/config/distribution.js
+++ b/js/config/distribution.js
@@ -15,273 +15,339 @@ var onix_meta = {
 			"values": [
 				{
 					"id": "01",
-					"name": {
-						"en": "LIA Compliance Scheme"
+					"en": {
+						"name": "LIA Compliance Scheme", 
+						"desc": "(Proprietary scheme)"
 					}
 				},
 				{
 					"id": "02",
-					"name": {
-						"en": "EPUB Accessibility Specification 1.0 A"
-					}
+					"en": {
+						"name": "EPUB Accessibility Specification 1.0 A",
+						"desc": "Conforms with the requirements of EPUB Accessibility Spec 1.0 and WCAG level A. <ProductFormFeatureDescription> may carry a URL linking to a compliance report or certification provided by an independent third party certifier. In the absence of a URL, conformance with the requirements of the Accessibility Specification is self-certified by the publisherConforms with the requirements of EPUB Accessibility Spec 1.0 and WCAG level A. <ProductFormFeatureDescription> may carry a URL linking to a compliance report or certification provided by an independent third party certifier. In the absence of a URL, conformance with the requirements of the Accessibility Specification is self-certified by the publisher"
+					},
+					"optionalFields": ["ProductFormFeatureDescription"]
 				},
 				{
 					"id": "03",
-					"name": {
-						"en": "EPUB Accessibility Specification 1.0 AA"
-					}
+					"en": {
+						"name": "EPUB Accessibility Specification 1.0 AA",
+						"desc": "Conforms with the requirements of EPUB Accessibility Spec 1.0 and WCAG level AA. <ProductFormFeatureDescription> may carry a URL linking to a compliance report or certification provided by an independent third party certifier. In the absence of a URL, conformance with the requirements of the Accessibility Specification is self-certified by the publisher"
+					},
+					"optionalFields": ["ProductFormFeatureDescription"]
 				},
 				{
 					"id": "04",
-					"name": {
-						"en": "EPUB Accessibility Specification 1.1"
-					}
+					"en": {
+						"name": "EPUB Accessibility Specification 1.1",
+						"desc": "Conforms with the requirements of EPUB Accessibility Spec v1.1 – see https://www.w3.org/TR/epub-a11y-11/. <ProductFormFeatureDescription> may carry a URL linking to a compliance report or certification provided by an independent third-party certifier. In the absence of a URL, conformance with the requirements of the Accessibility Specification is self- certified by the publisher. Use with other List 196 codes to indicate WCAG version and level, ARIA inclusion. Only for use in ONIX 3.0 or later"
+					},
+					"optionalFields": ["ProductFormFeatureDescription"]
 				},
 				{
 					"id": "08",
-					"name": {
-						"en": "Unknown accessibility"
-					}
+					"en": {
+						"name": "Unknown accessibility",
+						"desc": "Product has not yet been assessed for accessibility, or no or insufficient accessibility information is provided. It should be treated as likely to be inaccessible (and also may not have been checked for hazards). <ProductFormFeatureDescription> may carry details of why the accessibility of the title is unknown. Only for use in ONIX 3.0 or later"
+					},
+					"optionalFields": ["ProductFormFeatureDescription"]
 				},
 				{
 					"id": "09",
-					"name": {
-						"en": "Inaccessible, or known limited accessibility"
-					}
+					"en": {
+						"name": "Inaccessible, or known limited accessibility",
+						"desc": "Known to lack significant features required for broad accessibility. Details of and reasons for limitations on accessibility can be given in <ProductFormFeatureDescription>. Only for use in ONIX 3.0 or later"
+					},
+					"optionalFields": ["ProductFormFeatureDescription"]
 				},
 				{
 					"id": "10",
-					"name": {
-						"en": "No reading system accessibility options actively disabled (except)"
+					"en": {
+						"name": "No reading system accessibility options actively disabled (except)",
+						"desc": "No accessibility features or content rendering options offered by the reading system, device or reading software (including but not limited to the ability to modify or choose text size or typeface, word and line spacing, zoom level, text or background color, or use of text-to-speech) are limited, disabled, overridden or otherwise unusable with the product EXCEPT – in ONIX 3 messages only – those specifically noted as subject to restriction or prohibition in <EpubUsageConstraint>. Note that provision of any significant part of the textual content as images (ie as pictures of text, rather than as ‘text-as-text’, and without any textual equivalent) or the application of some technical protection measures (DRM), inevitably prevents full use of these accessibility options. Code 10 means ‘this e-publication is accessible to the full extent that the file format and types of content allow, on a specific reading device, by default, without necessarily inluding any additions such as textual descriptions of images or enhanced navigation. Note that for reflowable e-books, this means code 36 also applies, although code 10 can also be used with accessible non-reflowable (fixed-format) e-publications and with audio material. Should be used with other codes that describe any additions to enhance the level of accessibility"
 					}
 				},
 				{
 					"id": "11",
-					"name": {
-						"en": "Table of contents navigation"
+					"en": {
+						"name": "Table of contents navigation",
+						"desc": "Table of contents allows direct (eg hyperlinked) access to all levels of text organization above individual paragraphs (eg to all sections and subsections) and to all tables, figures, illustrations etc. Non-textual items such as illustrations, tables, audio or video content may be directly accessible from the Table of contents, or from a similar List of illustrations, List of tables, etc"
 					}
 				},
 				{
 					"id": "12",
-					"name": {
-						"en": "Index navigation"
+					"en": {
+						"name": "Index navigation",
+						"desc": "Index provides direct (eg hyperlinked) access to uses of the index terms in the document body"
 					}
 				},
 				{
 					"id": "13",
-					"name": {
-						"en": "Single logical reading order"
+					"en": {
+						"name": "Single logical reading order",
+						"desc": "All or substantially all textual matter is arranged in a single logical reading order (including text that is visually presented as separate from the main text flow, eg in boxouts, captions, tables, footnotes, endnotes, citations, etc). Non-textual content is also linked from within this logical reading order. (Purely decorative non-text content can be ignored). All or substantially all audio content should also have a single logical ‘reading order’, which is the order the content should be presented to the listener"
 					}
 				},
 				{
 					"id": "14",
-					"name": {
-						"en": "Short alternative textual descriptions"
+					"en": {
+						"name": "Short alternative textual descriptions",
+						"desc": "All or substantially all non-text content has short alternative (textual) descriptions, usually provided via alt attributes. Note this applies to normal images (eg photographs, charts and diagrams) and also to any embedded audio, video etc. Audio and video content should include alternative descriptions suitable for hearing-impaired as well as for visually-impaired readers. (Purely decorative non-text content can be ignored, but the accessibility of resources delivered via a network connection rather than as part of the e-publication package must be included)"
 					}
 				},
 				{
 					"id": "15",
-					"name": {
-						"en": "Full alternative textual descriptions"
+					"en": {
+						"name": "Full alternative textual descriptions",
+						"desc": "All or substantially all non-text content has full alternative (textual) descriptions. Note this applies to normal images (eg photographs, charts and diagrams) and also to any embedded audio, video etc. Audio and video content should include full alternative descriptions (eg audio-described video) and transcript, subtitles or captions (whether closed or open) suitable for hearing-impaired as well as for visually-impaired readers. (Purely decorative non-text content can be ignored, but the accessibility of resources delivered via a network connection rather than as part of the e-publication package must be included)"
 					}
 				},
 				{
 					"id": "16",
-					"name": {
-						"en": "Visualised data also available as non-graphical data"
+					"en": {
+						"name": "Visualised data also available as non-graphical data",
+						"desc": "Where data visualisations are provided (eg graphs and charts), the underlying data is also available in non-graphical (usually tabular, textual) form"
 					}
 				},
 				{
 					"id": "17",
-					"name": {
-						"en": "Accessible math content as MathML"
+					"en": {
+						"name": "Accessible math content as MathML",
+						"desc": "Mathematical content such as equations is usable with assistive technology, through use of MathML. Semantic MathML is preferred but Presentational MathML is acceptable"
 					}
 				},
 				{
 					"id": "18",
-					"name": {
-						"en": "Accessible chemistry content as ChemML"
+					"en": {
+						"name": "Accessible chemistry content as ChemML",
+						"desc": "Chemistry content such as chemical formulae is usable with assistive technology, through use of ChemML"
 					}
 				},
 				{
 					"id": "19",
-					"name": {
-						"en": "Print-equivalent page numbering"
+					"en": {
+						"name": "Print-equivalent page numbering",
+						"desc": "For a reflowable e-publication, contains references to the page numbering of an equivalent printed product."
 					}
 				},
 				{
 					"id": "20",
-					"name": {
-						"en": "Synchronised pre-recorded audio"
+					"en": {
+						"name": "Synchronised pre-recorded audio",
+						"desc": "Text-synchronised pre-recorded audio narration (natural or synthesised voice) is included for substantially all textual matter, including all alternative descriptions, eg via a SMIL media overlay"
 					}
 				},
 				{
 					"id": "21",
-					"name": {
-						"en": "Text-to-speech hinting provided"
+					"en": {
+						"name": "Text-to-speech hinting provided",
+						"desc": "Text-to-speech has been optimised through provision of PLS lexicons, SSML or CSS Speech synthesis hints or other speech synthesis markup languages or hinting"
 					}
 				},
 				{
 					"id": "22",
-					"name": {
-						"en": "Language tagging provided"
+					"en": {
+						"name": "Language tagging provided",
+						"desc": "The language of the text has been specified (eg via the HTML or XML lang attribute) to optimise text-to-speech (and other alternative renderings), both at whole document level and, where appropriate, for individual words, phrases or passages in a different language"
 					}
 				},
 				{
 					"id": "24",
-					"name": {
-						"en": "Dyslexia readability"
+					"en": {
+						"name": "Dyslexia readability",
+						"desc": "Specialised font, character and/or line spacing, justification and paragraph spacing, coloring and other options provided specifically to improve readability for dyslexic readers."
 					}
 				},
 				{
 					"id": "25",
-					"name": {
-						"en": "Use of color is not sole means of conveying information"
+					"en": {
+						"name": "Use of color is not sole means of conveying information",
+						"desc": "For readers with color vision deficiency, use of color (eg in diagrams, graphs and charts, in prompts or on buttons inviting a response) is not the sole means of graphical distinction or of conveying information. Only for use in ONIX 3.0 or later"
 					}
 				},
 				{
 					"id": "26",
-					"name": {
-						"en": "Use of high contrast between text and background color"
+					"en": {
+						"name": "Use of high contrast between text and background color",
+						"desc": "Body text is presented with a contrast ratio of at least 4.5:1 (or 3:1 for large/heading text). Only for use in ONIX 3.0 or later"
 					}
 				},
 				{
 					"id": "27",
-					"name": {
-						"en": "Use of high contrast between foreground and background audio"
+					"en": {
+						"name": "Use of high contrast between foreground and background audio",
+						"desc": "Foreground audio content (eg voice) is presented with no or low background noise (eg ambient sounds, music), at least 20dB below the level of the foreground, or background noise can be switched off (eg via an alternative audio track). Brief and occasional sound effects may be as loud as foreground voice so long as they are isolated from the foreground. Only for use in ONIX 3.0 or later"
 					}
 				},
 				{
 					"id": "28",
-					"name": {
-						"en": "Full alternative audio descriptions"
+					"en": {
+						"name": "Full alternative audio descriptions",
+						"desc": "All or substantially all non-text content has full alternative descriptions as pre-recorded audio. Note this applies to normal images (eg photographs, charts and diagrams) and also to any embedded video etc. Video content should include full alternative descriptions (eg audio-described video) and transcript, subtitles or captions (whether closed or open) suitable for hearing-impaired as well as for visually-impaired readers. (Purely decorative non-text content can be ignored, but the accessibility of resources delivered via a network connection rather than as part of the e-publication package must be included). Only for use in ONIX 3.0 or later"
 					}
 				},
 				{
 					"id": "29",
-					"name": {
-						"en": "Next / Previous structural navigation"
+					"en": {
+						"name": "Next / Previous structural navigation",
+						"desc": "All levels of heading and other structural elements of the content are correctly marked up and (if applicable) numbered, to enable fast next heading / previous heading, next chapter / previous chapter navigation without returning to the table of contents. Only for use in ONIX 3.0 or later"
 					}
 				},
 				{
 					"id": "30",
-					"name": {
-						"en": "ARIA roles provided"
+					"en": {
+						"name": "ARIA roles provided",
+						"desc": "Accessible Rich Internet Applications (ARIA) roles are used to organize and improve the structural or landmark navigation of the publication (eg to identify key sections of the content and the purpose of hyperlinks). Only for use in ONIX 3.0 or later"
 					}
 				},
 				{
 					"id": "31",
-					"name": {
-						"en": "Accessible controls provided"
+					"en": {
+						"name": "Accessible controls provided",
+						"desc": "Where interactive content is included in the product, controls are labelled to make their use clear. Only for use in ONIX 3.0 or later"
 					}
 				},
 				{
 					"id": "32",
-					"name": {
-						"en": "Landmark navigation"
+					"en": {
+						"name": "Landmark navigation",
+						"desc": "E-publication includes basic landmark navigation (usually less detailed than TOC-based navigation). Only for use in ONIX 3.0 or later"
 					}
 				},
 				{
 					"id": "34",
-					"name": {
-						"en": "Accessible chemistry content (as MathML)"
+					"en": {
+						"name": "Accessible chemistry content (as MathML)",
+						"desc": "Only for use in ONIX 3.0 or later"
 					}
 				},
 				{
 					"id": "35",
-					"name": {
-						"en": "Accessible math content (as LaTeX)"
+					"en": {
+						"name": "Accessible math content (as LaTeX)",
+						"desc": "Only for use in ONIX 3.0 or later"
 					}
 				},
 				{
 					"id": "36",
-					"name": {
-						"en": "All textual content can be modified"
+					"en": {
+						"name": "All textual content can be modified",
+						"desc": "E-publication does not restrict the ability of users to modify and reflow the display of any textual content to the full extent allowed by the reading system (eg to change the text size or typeface, line height and word spacing, colors). Only for use in ONIX 3.0 or later."
 					}
 				},
 				{
 					"id": "37",
-					"name": {
-						"en": "Use of ultra-high contrast between text foreground and background"
+					"en": {
+						"name": "Use of ultra-high contrast between text foreground and background",
+						"desc": "Body text is presented with a contrast ratio of at least 7:1 (or 4.5:1 for large/heading text). Only for use in ONIX 3.0 or later	"
 					}
 				},
 				{
 					"id": "38",
-					"name": {
-						"en": "Unusual words or abbreviations explained"
+					"en": {
+						"name": "Unusual words or abbreviations explained",
+						"desc": "E-publication provides explanations for unusual words, abbreviations, acronyms, idioms, jargon in an accessible form, such as glossaries, scripted pop-ups. Only for use in ONIX 3.0 or later"
 					}
 				},
 				{
 					"id": "39",
-					"name": {
-						"en": "Supplementary material to an audiobook is accessible"
+					"en": {
+						"name": "Supplementary material to an audiobook is accessible",
+						"desc": "All supplementary visual or textual material necessary for understanding of an audiobook, is available as pre-recorded audio, or has full alternative text that can be read via text-to- speech. Only for use in ONIX 3.0 or later"
 					}
 				},
 				{
 					"id": "40",
-					"name": {
-						"en": "Link purposes clear"
+					"en": {
+						"name": "Link purposes clear",
+						"desc": "Where links are included in the product, the purpose or functionality of each link is apparent from the link text alone – or where it is unclear, separate link descriptions provided). Only for use in ONIX 3.0 or later"
+					}
+				},
+				{
+					"id": "51",
+					"en": {
+						"name": "All non-decorative content supports reading via pre-recorded audio",
+						"desc": "All contents of the digital publication necessary to use and understanding, including any text, images (via alternative descriptions), video (via audio description) is fully accessible via suitable audio reproduction. The entire publication can be navigated and ‘read’ using only pre-recorded sound, and does not require visual or tactile perception. NB this implies that all <ProductContent> types listed can be accessed without sight. Only for use in ONIX 3.0 or later"
 					}
 				},
 				{
 					"id": "52",
-					"name": {
-						"en": "All non-decorative content supports reading without sight"
+					"en": {
+						"name": "All non-decorative content supports reading without sight",
+						"desc": "Sometimes termed ‘screen reader-friendly’, and fully supports multiple forms of non-visual reading. All contents of the digital publication necessary to use and understanding, including text, images (via their alternative descriptions), audio and video material (via their transcripts, descriptions, captions or subtitles) are fully accessible via suitable reading devices, for example text-to-speech screen readers or tactile reading devices (‘Braille displays’), and nothing in the digital publication prevents or blocks the use of alternative reading modes. The entire publication can be navigated and ‘read’ using only text rendered via sound or touch, and does not require visual perception. NB this implies that all <ProductContent> types listed can be accessed without sight. Only for use in ONIX 3.0 or later"
 					}
 				},
 				{
 					"id": "75",
-					"name": {
-						"en": "EEA Exception1 – Micro-enterprises"
-					}
+					"en": {
+						"name": "EEA Exception1 – Micro-enterprises",
+						"desc": "Digital product falls under European Accessibility Act exception for Micro-enterprises (as defined by current regulations). The product may not have to comply with requirements of the EAA if the publisher is a micro-enterprise. <ProductFormFeatureDescription> may carry details justifying the exception claim. Use for example with code 09. Only for use in ONIX 3.0 or later"
+					},
+					"optionalFields": ["ProductFormFeatureDescription"]
 				},
 				{
 					"id": "76",
-					"name": {
-						"en": "EAA exception 2 – Disproportionate burden"
-					}
+					"en": {
+						"name": "EAA exception 2 – Disproportionate burden",
+						"desc": "Digital product falls under European Accessibility Act exception for Disproportionate burden (as defined by current regulations). The product may not have to comply with requirements of the EAA if doing so would financially overburden the publisher. <ProductFormFeatureDescription> may carry details justifying the exception claim. Use for example with code 09. Only for use in ONIX 3.0 or later"
+					},
+					"optionalFields": ["ProductFormFeatureDescription"]
 				},
 				{
 					"id": "77",
-					"name": {
-						"en": "EAA exception 3 – Fundamental modification"
-					}
+					"en": {
+						"name": "EAA exception 3 – Fundamental modification",
+						"desc": "Digital product falls under European Accessibility Act exception for Fundamental modification (as defined by current regulations). The product may not have to comply with requirements of the EAA if doing so requires a fundamental modification of the nature of the product or service. <ProductFormFeatureDescription> may carry details justifying the exception claim. Use for example with code 09. Only for use in ONIX 3.0 or later"
+					},
+					"optionalFields": ["ProductFormFeatureDescription"]
 				},
 				{
 					"id": "80",
-					"name": {
-						"en": "WCAG v2.0"
-					}
+					"en": {
+						"name": "WCAG v2.0",
+						"desc": "Conforms with the requirements of WCAG version 2.0 – see https://www.w3.org/WAI/standards-guidelines/wcag/. <ProductFormFeatureDescription> may carry a URL linking to a compliance report or certification provided by an independent third-party certifier. In the absence of a URL, conformance with the requirements of the Specification is self-certified by the publisher. Should be used in combination with code 04. Only for use in ONIX 3.0 or later"
+					},
+					"optionalFields": ["ProductFormFeatureDescription"]
 				},
 				{
 					"id": "81",
-					"name": {
-						"en": "WCAG v2.1"
-					}
+					"en": {
+						"name": "WCAG v2.1",
+						"desc": "Only for use in ONIX 3.0 or later"
+					},
+					"optionalFields": ["ProductFormFeatureDescription"]
 				},
 				{
 					"id": "82",
-					"name": {
-						"en": "WCAG v2.2"
-					}
+					"en": {
+						"name": "WCAG v2.2",
+						"desc": "Only for use in ONIX 3.0 or later"
+					},
+					"optionalFields": ["ProductFormFeatureDescription"]
 				},
 				{
 					"id": "84",
-					"name": {
-						"en": "WCAG level A"
-					}
+					"en": {
+						"name": "WCAG level A",
+						"desc": "Conforms with the requirements of WCAG level A. <ProductFormFeatureDescription> may carry a URL linking to a compliance report or certification provided by an independent third-party certifier. In the absence of a URL, conformance with the requirements of the Specification is self-certified by the publisher. Should be used in combination with code 04. Only for use in ONIX 3.0 or later"
+					},
+					"optionalFields": ["ProductFormFeatureDescription"]
 				},
 				{
 					"id": "85",
-					"name": {
-						"en": "WCAG level AA"
-					}
+					"en": {
+						"name": "WCAG level AA",
+						"desc": "Only for use in ONIX 3.0 or later"
+					},
+					"optionalFields": ["ProductFormFeatureDescription"]
 				},
 				{
 					"id": "86",
-					"name": {
-						"en": "WCAG level AAA"
-					}
+					"en": {
+						"name": "WCAG level AAA",
+						"desc": "Only for use in ONIX 3.0 or later"
+					},
+					"optionalFields": ["ProductFormFeatureDescription"]
 				}
 			]
 		},

--- a/js/distribution.js
+++ b/js/distribution.js
@@ -177,15 +177,19 @@ var smartDistribution = (function() {
 			
 				for (var j = 0; j < property.values.length; j++) {
 		    		
+		    		var dt = document.createElement('dt');
+		    		
 		    		var input = document.createElement('input');
 		    			input.setAttribute('type','checkbox');
 		    			input.setAttribute('id','onix'+property.values[j].id);
 		    		
-		    		var input_label = document.createElement('dt');
+		    		var input_label = document.createElement('label');
 			    		input_label.appendChild(input);
 			    		input_label.appendChild(document.createTextNode(' ' + property.values[j].id + ' - ' + property.values[j][smart_lang].name));
 		    		
-		    		dl.appendChild(input_label);
+		    		dt.appendChild(input_label);
+		    		
+		    		dl.appendChild(dt);
 		    		
 		    		var dd2 = document.createElement('dd');
 			    		dd2.appendChild(document.createTextNode(property.values[j][smart_lang].desc));

--- a/js/distribution.js
+++ b/js/distribution.js
@@ -136,58 +136,89 @@ var smartDistribution = (function() {
 		
 		var meta_fields = document.getElementById('distribution-fields');
 		
+		var dl = document.createElement('dl');
+			dl.setAttribute('class', 'onix');
+		
 		for (var i = 0; i < onix_meta.properties.length; i++) {
 			
 			var property = onix_meta.properties[i];
 			
-			var container = document.createElement(property.type == 'checkbox' ? 'fieldset' : 'div');
-				container.setAttribute('class', 'onix');
-			
-			var label = document.createElement(property.type == 'checkbox' ? 'legend' : 'label');
-			
 			if (property.type != 'checkbox') {
-				label.setAttribute('for', 'onix'+property.id);
-				label.appendChild(document.createTextNode(property.id + ' - '));
-			}
+				var dt = document.createElement('dt');
+				
+					dt.setAttribute('for', 'onix'+property.id);
+					dt.appendChild(document.createTextNode(property.id + ' - '));
 			
-			label.appendChild(document.createTextNode(property.name[smart_lang]));
-			container.appendChild(label);
+				dt.appendChild(document.createTextNode(property.name[smart_lang]));
+				dl.appendChild(dt);
+			}
 			
 			if (property.type == 'textarea') {
 				var textarea = document.createElement('textarea');
 					textarea.setAttribute('id', 'onix'+property.id);
 					textarea.setAttribute('rows', 5);
-				container.appendChild(textarea);
+				
+				var dd = document.createElement('dd');
+					dd.appendChild(textarea);
+				dl.appendChild(dd);
 			}
 			
 			else if (property.type == 'text') {
 	    		var input = document.createElement('input');
 	    			input.setAttribute('type','text');
 	    			input.setAttribute('id','onix'+property.id);
-	    		container.appendChild(input);
+
+				var dd = document.createElement('dd');
+	    			dd.appendChild(input);
+				dl.appendChild(dd);
 			}
 			
 			else if (property.type == 'checkbox') {
 			
 				for (var j = 0; j < property.values.length; j++) {
-		    		var input_label = document.createElement('label');
 		    		
 		    		var input = document.createElement('input');
 		    			input.setAttribute('type','checkbox');
 		    			input.setAttribute('id','onix'+property.values[j].id);
 		    		
-		    		input_label.appendChild(input);
-		    		input_label.appendChild(document.createTextNode(' ' + property.values[j].id + ' - ' + property.values[j].name[smart_lang]));
-		    		container.appendChild(input_label);
+		    		var input_label = document.createElement('dt');
+			    		input_label.appendChild(input);
+			    		input_label.appendChild(document.createTextNode(' ' + property.values[j].id + ' - ' + property.values[j][smart_lang].name));
+		    		
+		    		dl.appendChild(input_label);
+		    		
+		    		var dd2 = document.createElement('dd');
+			    		dd2.appendChild(document.createTextNode(property.values[j][smart_lang].desc));
+		    		
+		    		if (property.values[j].hasOwnProperty('optionalFields')) {
+		    			if (property.values[j].optionalFields.includes('ProductFormFeatureDescription')) {
+		    				var div = document.createElement('div');
+		    					div.setAttribute('class', 'onix-optional');
+		    				
+		    				var label = document.createElement('label');
+		    					label.appendChild(document.createTextNode('ProductFormFeatureDescription: '));
+		    				
+		    				var input = document.createElement('input');
+		    					input.setAttribute('type', 'text');
+		    					input.setAttribute('id', property.values[j].id + '-ProductFormFeatureDescription');
+		    				label.appendChild(input);
+		    				
+		    				div.appendChild(label);
+		    				
+		    				dd2.appendChild(div);
+		    			}
+		    		}
+		    		
+					dl.appendChild(dd2);
 				}
 			}
 			
 			else {
 				console.log('Unknown property type ' + property.type);
 			}
-			
-			meta_fields.appendChild(container);
 		}
+		
+		meta_fields.appendChild(dl);
 		
 		/* sync summary changes */
 		$('#onix00').change( function(){
@@ -223,11 +254,18 @@ var smartDistribution = (function() {
 		
 		/* add any checked fields */
 		for (var i = 1; i < 93; i++) {
-			var onix_id = (i < 10 ? '0'+String(i) : i);
+			var onix_id = String(i).padStart(2,'0');
 			var checkbox = document.getElementById('onix'+onix_id);
 			
 			if (checkbox && checkbox.checked) {
-				onix_metadata += formatONIXEntry( {value: onix_id } );
+				var opt = { value: onix_id };
+				
+				var desc = document.getElementById(onix_id + '-ProductFormFeatureDescription');
+				if (desc) {
+					opt.description = desc.value;
+				}
+				
+				onix_metadata += formatONIXEntry(opt);
 			}
 		}
 		
@@ -257,7 +295,7 @@ var smartDistribution = (function() {
 			feature += '\t\t<productFormFeatureType>09</producFormFeatureType>\n';
 			feature += '\t\t<productFormFeatureValue>' + options.value + '</productFormFeatureValue>\n';
 			
-			if (options.hasOwnProperty('description')) {
+			if (options.hasOwnProperty('description') && options.description !== '') {
 				feature += '\t\t<productFormFeatureDescription>' + options.description + '<productFormFeatureDescription>\n';
 			}
 			

--- a/js/manage.js
+++ b/js/manage.js
@@ -164,14 +164,23 @@ var smartManage = (function() {
 		evaluationJSON.distribution = {};
 		
 			evaluationJSON.distribution.onix = {};
+			evaluationJSON.distribution.ProductFormFeatureDescription = {};
+			
 			evaluationJSON.distribution.onix['00'] = document.getElementById('onix00').value.trim();
-			for (var o = 10; o < 30; o++) {
-				var onix_id = o < 10 ? '0' + String(o) : o;
+			
+			for (var o = 1; o < 93; o++) {
+				var onix_id = String(o).padStart(2,'0');
 				var onix_chkbox = document.getElementById('onix' + onix_id);
 				if (onix_chkbox) {
 					evaluationJSON.distribution.onix[onix_id] = onix_chkbox.checked;
 				}
+				
+				var onix_opt = document.getElementById(onix_id + '-ProductFormFeatureDescription');
+				if (onix_opt) {
+					evaluationJSON.distribution.ProductFormFeatureDescription[onix_id] = onix_opt.value;
+				}
 			}
+			
 			for (var p = 93; p < 100; p++) {
 				evaluationJSON.distribution.onix[p] = document.getElementById('onix'+p).value.trim();
 			}
@@ -460,17 +469,22 @@ var smartManage = (function() {
 		if (evaluationJSON.hasOwnProperty('distribution')) {
 			if (evaluationJSON.distribution.hasOwnProperty('onix')) {
 				for (var onix_id in evaluationJSON.distribution.onix) {
+					var padded_id = onix_id.padStart(2,'0');
 					if (onix_id == 0 || onix_id > 90) {
-						document.getElementById('onix' + onix_id).value = evaluationJSON.distribution.onix.hasOwnProperty(onix_id) ? evaluationJSON.distribution.onix[onix_id] : '';
+						document.getElementById('onix' + padded_id).value = evaluationJSON.distribution.onix.hasOwnProperty(padded_id) ? evaluationJSON.distribution.onix[padded_id] : '';
 					}
 					else {
-						if (evaluationJSON.distribution.onix[onix_id]) {
-							var id = 'onix' + onix_id;
+						if (evaluationJSON.distribution.onix[padded_id]) {
+							var id = 'onix' + padded_id;
 							var input = document.getElementById(id);
 							if (!input.checked) {
 								input.checked = true;
 								smartDiscovery.syncFeature('distribution', id, true);
 							}
+						}
+						
+						if (evaluationJSON.distribution.hasOwnProperty('ProductFormFeatureDescription') && evaluationJSON.distribution.ProductFormFeatureDescription.hasOwnProperty(padded_id)) {
+							document.getElementById(padded_id + '-ProductFormFeatureDescription').value = evaluationJSON.distribution.ProductFormFeatureDescription[padded_id];
 						}
 					}
 				}

--- a/new.html
+++ b/new.html
@@ -16,6 +16,14 @@
 				<h2>What's New</h2>
 				
 				<dl>
+					<dt>May 3, 2024 &#8212; Updated distribution metadata</dt>
+					<dd>
+						<p>The layout of the Distribution tab has been updated to include the descriptions for
+							each onix value. In addition, it is now possible to add a
+							<code>ProductFormFeatureDescription</code> for onix fields that accept additional
+							information.</p>
+					</dd>
+					
 					<dt>March 19, 2024 &#8212; Accessibility metadata wizard</dt>
 					<dd>
 						<p>A new metadata wizard is available for beta testing on the Discovery tab. The wizard

--- a/php/version.php
+++ b/php/version.php
@@ -1,4 +1,4 @@
 
 <?php
-	$smart_version = '2024-04-26T12:00:00Z'; # used to refresh all css and js in browsers 
+	$smart_version = '2024-05-03T12:00:00Z'; # used to refresh all css and js in browsers 
 ?>

--- a/smart.php
+++ b/smart.php
@@ -136,7 +136,7 @@ JS;
 	
 	<body class="tabs">
 		<header>
-			<h1><img src="images/daisy_logo.png" class="logo" alt="DAISY"/> <span property="dcterms:title">Ace <span class="smart_hd">SMART</span> &#8212; Evaluation</span></h1>
+			<h1><img src="images/daisy_high.jpg" class="logo" alt="DAISY"/> <span property="dcterms:title">Ace <span class="smart_hd">SMART</span> &#8212; Evaluation</span></h1>
 			
 			<nav class="appmenu" aria-label="application menu">
 				<a href="#" id="validate-button"><img src="images/validate.png" alt="validate" title="Validate"/></a>
@@ -394,8 +394,8 @@ JS;
 					
 					<div id="extension-results"></div>
 					
-					<fieldset id="eval-info">
-						<legend>Evaluation Info:</legend>
+					<fieldset id="eval-info" aria-labelledby="ei-legend">
+						<legend id="ei-legend" hidden="hidden">Evaluation Info</legend>
 						<label class="data"><span>Evaluator:<img src="/images/asterisk.png" alt="required"/></span> <input type="text" id="certifiedBy" aria-required="true"/></label>
 						<label class="data"><span>Credential:</span> <input type="text" id="certifierCredential"/></label>
 						<label class="data"><span>Link to report:</span> <input type="text" id="certifierReport"/></label>


### PR DESCRIPTION
This pull request:

- reformats the distribution page layout to use a dl for the checkboxes;
- adds the onix field descriptions and productformfeaturedescription input boxes to the dd tags;
- updates the onix generator to add the productformfeaturedescription values when present;
- removes grey boxes from various input groups throughout the application and cleans up the styling a bit